### PR TITLE
USB speed tester

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "workbench.colorCustomizations": {
+        "minimap.background": "#00000000",
+        "scrollbar.shadow": "#00000000"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# mac-tools
+# MAC Tools - for Apple MacBooks
+
+## Description
+
+This repository contains a collection of tools and scripts for Apple MacBooks. The tools are written in Bash.
+
+## Tools
+
+- [USB speed tester](usb-tester/README.md)

--- a/usb-tester/01-write-test.sh
+++ b/usb-tester/01-write-test.sh
@@ -1,0 +1,18 @@
+number_of_files=50
+output_directory=/Volumes/SIPP-256
+
+start_time=$(date +%s)
+
+for i in $(seq 1 $number_of_files); do
+  dd if=/dev/urandom of=$output_directory/music_file_$i.mp3 bs=1M count=$(( RANDOM % 35 + 10 )) oflag=sync status=none
+done
+
+end_time=$(date +%s)
+
+# Prevent division by zero
+time_taken=$(( end_time - start_time ))
+if [ "$time_taken" -eq 0 ]; then
+  time_taken=1
+fi
+
+echo "Write Speed KPI: $(( number_of_files * 25 / time_taken )) MB/s"

--- a/usb-tester/01-write-test.sh
+++ b/usb-tester/01-write-test.sh
@@ -1,5 +1,5 @@
 number_of_files=50
-output_directory=/Volumes/SIPP-256
+output_directory=/Volumes/SIPP-SILVER
 
 start_time=$(date +%s)
 

--- a/usb-tester/02-read-test.sh
+++ b/usb-tester/02-read-test.sh
@@ -1,0 +1,12 @@
+number_of_files=50
+output_directory=/Volumes/SIPP-256
+
+start_time=$(date +%s)                                         
+
+for file in $output_directory/music_file_*.mp3; do
+  dd if="$file" of=/dev/null bs=1M status=none
+done
+
+end_time=$(date +%s)
+
+echo "Read Speed KPI: $(( $number_of_files * 25 / (end_time - start_time) )) MB/s"

--- a/usb-tester/02-read-test.sh
+++ b/usb-tester/02-read-test.sh
@@ -1,5 +1,5 @@
 number_of_files=50
-output_directory=/Volumes/SIPP-256
+output_directory=/Volumes/SIPP-SILVER
 
 start_time=$(date +%s)                                         
 

--- a/usb-tester/03-cleanup-files.sh
+++ b/usb-tester/03-cleanup-files.sh
@@ -1,0 +1,5 @@
+
+output_directory=/Volumes/SIPP-256
+
+rm $output_directory/music_file_*.mp3
+

--- a/usb-tester/03-cleanup-files.sh
+++ b/usb-tester/03-cleanup-files.sh
@@ -1,5 +1,5 @@
 
-output_directory=/Volumes/SIPP-256
+output_directory=/Volumes/SIPP-SILVER
 
 rm $output_directory/music_file_*.mp3
 

--- a/usb-tester/README.md
+++ b/usb-tester/README.md
@@ -1,0 +1,54 @@
+# USB speed tester
+
+## USB Tester Write Test Script
+
+This document provides an overview and explanation of the `01-write-test.sh` script used for testing USB write operations.
+
+### Script: `01-write-test.sh`
+
+### Description
+
+The `01-write-test.sh` script is designed to perform write tests on a USB device. It writes data to the USB device and verifies the integrity of the written data.
+
+### Usage
+
+To run the script, execute the following command in your terminal:
+
+```sh
+./01-write-test.sh
+```
+
+## USB Tester Read Test Script
+
+This document provides an overview and explanation of the `02-read-test.sh` script used for testing USB read operations.
+
+### Script: `02-read-test.sh`
+
+### Description
+
+The `02-read-test.sh` script is designed to perform read tests on a USB device. It reads data from the USB device and verifies the integrity of the read data.
+
+### Usage
+
+To run the script, execute the following command in your terminal:
+
+```sh
+./02-read-test.sh
+```
+
+## USB Tester Cleanup Files Script
+
+This document provides an overview and explanation of the `03-cleanup-files.sh` script used for cleaning up test files created during USB testing operations.
+
+### Script: `03-cleanup-files.sh`
+
+### Description
+
+The `03-cleanup-files.sh` script is designed to remove test files created during USB write and read tests. It ensures that the system is clean and free of temporary test files.
+
+### Usage
+
+To run the script, execute the following command in your terminal:
+
+```sh
+./03-cleanup-files.sh


### PR DESCRIPTION
# USB speed tester

## USB Tester Write Test Script

This document provides an overview and explanation of the `01-write-test.sh` script used for testing USB write operations.

### Script: `01-write-test.sh`

### Description

The `01-write-test.sh` script is designed to perform write tests on a USB device. It writes data to the USB device and verifies the integrity of the written data.

### Usage

To run the script, execute the following command in your terminal:

```sh
./01-write-test.sh
```

## USB Tester Read Test Script

This document provides an overview and explanation of the `02-read-test.sh` script used for testing USB read operations.

### Script: `02-read-test.sh`

### Description

The `02-read-test.sh` script is designed to perform read tests on a USB device. It reads data from the USB device and verifies the integrity of the read data.

### Usage

To run the script, execute the following command in your terminal:

```sh
./02-read-test.sh
```

## USB Tester Cleanup Files Script

This document provides an overview and explanation of the `03-cleanup-files.sh` script used for cleaning up test files created during USB testing operations.

### Script: `03-cleanup-files.sh`

### Description

The `03-cleanup-files.sh` script is designed to remove test files created during USB write and read tests. It ensures that the system is clean and free of temporary test files.

### Usage

To run the script, execute the following command in your terminal:

```sh
./03-cleanup-files.sh
